### PR TITLE
Add NewLink/NewUrl to DefaultRemovePatterns

### DIFF
--- a/Source/Resources/DefaultRemovePatterns.json
+++ b/Source/Resources/DefaultRemovePatterns.json
@@ -1,4 +1,10 @@
 [
+     {
+        "linkName": "NewLink",
+        "urlPattern": "NewUrl",
+        "namePattern": "NewLink",
+        "partialMatch": false
+    },       
     {
         "linkName": "Facebook",
         "urlPattern": "*facebook.com*",


### PR DESCRIPTION
When adding a new link, Playnite defaults to NewLink & NewUrl. Adding a rule that matches both to the default remove patterns probably makes sense.